### PR TITLE
update register page text "Terms of Service and Honor Code"

### DIFF
--- a/mitx/lms/static/js/login-register.js
+++ b/mitx/lms/static/js/login-register.js
@@ -82,8 +82,16 @@ var periodicCaller = function () {
 }
 
 
+var updateRegisterTermsOfServiceText = function () {
+    $("#register .plaintext-field a").text(function () {
+        return $(this).text().replace('Terms of Service and Honor Code', 'Terms of Service');
+    });
+}
+
+
 window.onload = function () {
     periodicCaller();
+    updateRegisterTermsOfServiceText();
 }
 
 $(document).on('click', function(event) {

--- a/mitx/lms/templates/student_account/login_and_register.html
+++ b/mitx/lms/templates/student_account/login_and_register.html
@@ -31,7 +31,7 @@
 </%block>
 
 <%block name="header_extras">
-    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "account_recovery", "hinted_login"]:
+    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
         <script type="text/template" id="${template_name}-tpl">
             <%static:include path="student_account/${template_name}.underscore" />
         </script>


### PR DESCRIPTION
Update text `"Terms of Service and Honor Code"` to `"Terms of Service"` on register page through javascript.
<img width="730" alt="Screen Shot 2019-06-27 at 6 29 28 PM" src="https://user-images.githubusercontent.com/5072991/60270369-bdd32e80-9909-11e9-845b-842441733703.png">

Also remove `account_recovery` from `template_name` in `login_and_register.html` as there is no longer any corresponding underscore template and page will crash.

