### PR TITLE
Hide last legal link "HONOR" in footer

### DIFF
--- a/mitx/lms/templates/footer.html
+++ b/mitx/lms/templates/footer.html
@@ -54,7 +54,7 @@
     <div class="container">
       <nav class="nav-legal" aria-label="${_('Legal')}">
         <ul class="list-inline">
-          % for item_num, link in enumerate(footer['legal_links'], start=1):
+          % for item_num, link in enumerate(footer['legal_links'][:-1], start=1):
             <li class="nav-legal-0${item_num}">
               <a href="${link['url']}">${link['title']}</a>
             </li>


### PR DESCRIPTION
Hide last legal link "HONOR" in footer.
Show only `Privacy Policy` and `Terms of Service` links.

<img width="1400" alt="Screen Shot 2019-06-27 at 8 13 01 PM" src="https://user-images.githubusercontent.com/5072991/60277967-0691e400-9918-11e9-82d2-a550cdc5615f.png">
