### PR TITLE
Zub/mit text on account settings

### DIFF
--- a/mitx/lms/static/js/common-scripts.js
+++ b/mitx/lms/static/js/common-scripts.js
@@ -1,0 +1,61 @@
+/**
+ * Different common utility scripts for the site.
+*/
+
+window.onload = function () {
+    periodicPageCaller();
+};
+
+let edxTextPattern = new RegExp('edx', 'gi');
+
+let periodicPageCaller = function () {
+    let interval = setInterval(function () {
+        clearInterval(interval);
+
+        accountSettingsReplaceEdxWithMitxContent();
+    });
+};
+
+let accountSettingsReplaceEdxWithMitxContent = function () {
+    if (window.location.pathname === '/account/settings') {
+            let deleteMyAccountButton = $('body #delete-account-btn'),
+            alertContentElement = $('.modal-alert .alert-content');
+        $.each($('body .section .account-settings-header-subtitle'), function() {
+            if($(this).text().toLocaleLowerCase().includes('edx')) {
+                $(this).text(
+                    function () {
+                        return $(this).text().replace(edxTextPattern, 'MIT Open Learning Library');
+                    }
+                );
+            }
+        });
+
+        $('#account-deletion-container p').remove();
+        $('#account-deletion-container').prepend(
+            '<p class="account-settings-header-subtitle">We’re sorry to see you go!</p><p class="account-settings-header-subtitle">Please note: Deletion of your account and personal data is permanent and cannot be undone. MIT Open Learning Library will not be able to recover your account or the data that is deleted.</p><p class="account-settings-header-subtitle">Once your account is deleted, you cannot use it to take courses on the MIT Open Learning Library app or any other site hosted by MIT Open Learning Library.</p><p class="account-settings-header-subtitle">You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for <a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">printing or downloading a certificate</a>.</p><p class="account-settings-header-subtitle-warning"><strong>Warning: Account deletion is permanent.</strong> Please read the above carefully before proceeding. This is an irreversible action, and <strong>you will no longer be able to use the same email on MIT Open Learning Library.</strong></p>'
+        );
+        if (alertContentElement[0]){
+            alertContentElement.html('<p>Before proceeding, please activate your account and unlink all social media accounts.</p>')
+        }
+
+        deleteMyAccountButton.click(function() {
+            let interval = setInterval(function () {
+                clearInterval(interval);
+
+                accountDeleteModalMitxContent();
+            });
+        });
+    }
+};
+
+let accountDeleteModalMitxContent = function () {
+    let modalAlertTitleElement = $('body .modal-alert .alert-title');
+
+    modalAlertTitleElement.text(
+        modalAlertTitleElement.text().replace(edxTextPattern, 'MIT Open Learning Library')
+    );
+
+    $('body .modal-alert p').first().text(
+        'If you proceed, you cannot use it to take courses on the MIT Open Learning Library app or any other site hosted by MIT Open Learning Library.'
+    )
+};

--- a/mitx/lms/templates/main.html
+++ b/mitx/lms/templates/main.html
@@ -209,6 +209,7 @@ from pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/login-register.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/accordion.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/smooth-scroll.js')}" charset="utf-8"></script>
+  <script type="text/javascript" src="${static.url('js/common-scripts.js')}" charset="utf-8"></script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
 </body>
 </html>


### PR DESCRIPTION
On Account Settings page, replace `edX` with `MIT Open Learning Library`.
**Before:**
<img width="749" alt="Screen Shot 2019-07-03 at 6 36 19 PM" src="https://user-images.githubusercontent.com/5072991/60596644-db4d4000-9dc2-11e9-9a43-abfb4212dd9f.png">

**After:**

On Account Settings page, update `Delete My Account` section for `MIT Open Learning Library`.
**Before:**
**After:**
<img width="722" alt="Screen Shot 2019-07-03 at 6 36 07 PM" src="https://user-images.githubusercontent.com/5072991/60660759-ddbaa300-9e71-11e9-86bf-b1855dc81188.png">


**Updated `Delete My Account` section with MIT related content:**
<img width="806" alt="Screen Shot 2019-07-04 at 3 33 17 PM" src="https://user-images.githubusercontent.com/5072991/60660808-faef7180-9e71-11e9-840b-052e94444dc2.png">

<img width="866" alt="Screen Shot 2019-07-04 at 3 33 23 PM" src="https://user-images.githubusercontent.com/5072991/60660819-017de900-9e72-11e9-98b0-55229644c915.png">
