### PR TITLE
fix course start date issue on about page

### DIFF
--- a/mitx/lms/templates/courseware/course_about.html
+++ b/mitx/lms/templates/courseware/course_about.html
@@ -292,15 +292,13 @@ from six import string_types, text_type
             </li>
           %endif
 
-          % if course.end and not course.start_date_is_still_default:
+          % if course.end and course.start:
             <li class="important-dates-item visible-imp">
                 <span class="icon icon-clock" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Length:")}</p>
                 <%
-                    course_start_date = course.advertised_start or course.start
-                    course_end_date = course.end
-                    old_date = course_start_date.date()
-                    new_date = course_end_date.date()
+                    old_date = course.start.date()
+                    new_date = course.end.date()
                     date_delta = new_date - old_date
                     course_length = int(math.ceil(date_delta.days/7.0))
                 %>


### PR DESCRIPTION
Fix `Server Error` on courses about page if we have set the value for `Course Advertised Start` on page `settings/advanced/course-v1:TestX+CS001+2019_T1`.
<img width="962" alt="Screen Shot 2019-07-05 at 2 54 22 PM" src="https://user-images.githubusercontent.com/5072991/60714602-cd1f3100-9f34-11e9-888f-b8c9c1208ee5.png">


