### PR TITLE
Navbar updates: persist "My Courses", change "Courses"  text to "All Courses" and "Dashboard" text to "My Courses"

### DIFF
--- a/mitx/lms/static/sass/course/_course-about.scss
+++ b/mitx/lms/static/sass/course/_course-about.scss
@@ -66,6 +66,8 @@
 
                             a {
                                 display: inline-block;
+                                margin: 0 1rem 1rem 0;
+                                vertical-align: top;
                                 @include clearfix;
 
                                 strong {

--- a/mitx/lms/templates/header/navbar-authenticated.html
+++ b/mitx/lms/templates/header/navbar-authenticated.html
@@ -28,13 +28,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 <div class="nav-links">
   <div class="main">
+    <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+      <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
+            aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
+            ${_("My Courses")}
+      </a>
+    </div>
     % if show_dashboard_tabs:
-      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-        <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
-             aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
-             ${_("My Courses")}
-        </a>
-      </div>
       % if show_program_listing:
         <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
@@ -59,7 +59,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
       </div>
     % endif
     <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-      <a class="tab-nav-link" href="${marketing_link('COURSES')}">${_("Courses")}</a>
+      <a class="tab-nav-link" href="${marketing_link('COURSES')}">${_("All Courses")}</a>
     </div>
     <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
       <a class="tab-nav-link" href="${marketing_link('ABOUT')}">${_("About")}</a>

--- a/mitx/lms/templates/header/user_dropdown.html
+++ b/mitx/lms/templates/header/user_dropdown.html
@@ -32,7 +32,7 @@ displayname = self.real_user.profile.name
         % if resume_block:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("My Courses")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>


### PR DESCRIPTION
### Story link
https://edlyio.atlassian.net/browse/EDE-430

### Description
1. Persist `My Courses` link on navbar across all pages
![image](https://user-images.githubusercontent.com/42166091/80583217-602bd900-8a29-11ea-9af0-69e6b277b900.png)

![image](https://user-images.githubusercontent.com/42166091/80583310-79cd2080-8a29-11ea-87ac-22e6278d812f.png)

2. Change text of `Courses` to `All Courses`
![image](https://user-images.githubusercontent.com/42166091/80583369-8b162d00-8a29-11ea-9104-06328ea0e963.png)

3. Change `Dashboard` text to `My Courses` in user dropdown
![image](https://user-images.githubusercontent.com/42166091/80583501-b6991780-8a29-11ea-9616-735a65b5e123.png)

