### PR TITLE
Add tooltips on buttons on course about page

### DIFF
--- a/mitx/lms/templates/courseware/course_about.html
+++ b/mitx/lms/templates/courseware/course_about.html
@@ -176,7 +176,10 @@ from six import string_types, text_type
           <div id="register_error"></div>
         %else:
           %if allow_anonymous and show_courseware_link:
-            <a href="${course_target}">
+            <a
+              title="View the course as an anonymous user. Some content will be unavailable and progress will not be tracked."
+              data-toggle='tooltip'
+              href="${course_target}">
             <strong>${_("View Course")}</strong>
             </a>
           % endif
@@ -191,7 +194,12 @@ from six import string_types, text_type
             else:
               href_class = "register"
           %>
-          <a href="${reg_href}" class="${href_class}">
+          <a
+            href="${reg_href}"
+            class="${href_class}"
+            data-toggle="tooltip"
+            title="Enroll in the course to take advantage of advanced assessments and keep track of course progress."
+          >
             ${_("Enroll to Get Started")}
           </a>
           <div id="register_error"></div>

--- a/mitx/lms/templates/main.html
+++ b/mitx/lms/templates/main.html
@@ -79,6 +79,7 @@ from pipeline_mako import render_require_js_path_overrides
   % endif
   <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
   <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
+  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 
   <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}" />
 
@@ -221,6 +222,11 @@ from pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/accordion.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/smooth-scroll.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/common-scripts.js')}" charset="utf-8"></script>
+  <script>
+    (function(){
+      $('[data-toggle=tooltip]').tooltip();
+    })();
+  </script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
 </body>
 </html>


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-481

### Description
Apply the customizations requested in the document (document's link in the ticket).

Add texts on hover on buttons on course about page for public courses only.
![image](https://user-images.githubusercontent.com/42166091/82553211-0c6e6480-9b7d-11ea-9aa3-1f833739f124.png)

![image](https://user-images.githubusercontent.com/42166091/82553223-11cbaf00-9b7d-11ea-8854-74ed78cd240f.png)
