### PR TITLE
Add text on hover for course about page buttons

### DIFF
--- a/mitx/lms/static/sass/course/_course-about.scss
+++ b/mitx/lms/static/sass/course/_course-about.scss
@@ -12,6 +12,7 @@
                 box-shadow: none;
                 height: auto;
                 padding: 0;
+                overflow: visible;
 
                 .intro-inner-wrapper {
                     border: none;
@@ -64,21 +65,69 @@
                                 @include padding($baseline*0.25, $baseline*0.25, $baseline*0.3, $baseline*0.25);
                             }
 
-                            a {
+                            .banner-links {
                                 display: inline-block;
                                 margin: 0 1rem 1rem 0;
                                 vertical-align: top;
+                                width: $baseline*12.5;
+                                position: relative;
+
+                                &:hover {
+                                    .tooltip {
+                                        display: block;
+                                    }
+                                }
+
+                                .tooltip {
+                                    position: absolute;
+                                    top: 100%;
+                                    left: 50%;
+                                    width: 200px;
+                                    margin-left: -100px;
+                                    margin-top: 10px;
+                                    font-size: 13px;
+                                    border-radius: 5px;
+                                    padding: 10px;
+                                    background: black;
+                                    color: white;
+                                    display: none;
+                                    z-index: 10;
+
+                                    &:before {
+                                        content: "";
+                                        position: absolute;
+                                        bottom: 100%;
+                                        left: 50%;
+                                        margin-left: -4px;
+                                        border: 4px solid black;
+                                        border-width: 0 4px 4px;
+                                        border-color: transparent transparent black;
+                                    }
+                                }
+                            }
+
+                            a {
+                                display: block;
                                 @include clearfix;
+                                max-width: $baseline*12.5;
+
+                                &:focus {
+                                    ~ .tooltip {
+                                        display: block;
+                                    }
+                                }
 
                                 strong {
+                                    width: auto;
+                                    float: none;
                                     @extend %btn;
                                     @include padding($baseline*0.6, $baseline, $baseline*0.55, $baseline);
                                     background: $primary;
                                     border-color: $primary;
                                     box-shadow: none;
                                     text-shadow: none;
-                                    width: $baseline*13;
                                     border-radius: $border-radius;
+                                    display: block;
 
                                     &:hover {
                                         background: darken($primary, 5%);

--- a/mitx/lms/templates/courseware/course_about.html
+++ b/mitx/lms/templates/courseware/course_about.html
@@ -130,12 +130,15 @@ from six import string_types, text_type
         %if user.is_authenticated and registered:
           %if show_courseware_link:
             <span class="register disabled">${_("You are enrolled in this course")}</span>
-            <a href="${course_target}">
           %endif
 
           %if show_courseware_link:
-            <strong>${_("View Course")}</strong>
-            </a>
+            <div class="banner-links">
+              <a href="${course_target}">
+                <strong>${_("View Course")}</strong>
+              </a>
+              <span class="tooltip">View the course as an anonymous user. Some content will be unavailable and progress will not be tracked.</span>
+            </div>
           %endif
 
         %elif in_cart:
@@ -176,12 +179,13 @@ from six import string_types, text_type
           <div id="register_error"></div>
         %else:
           %if allow_anonymous and show_courseware_link:
-            <a
-              title="View the course as an anonymous user. Some content will be unavailable and progress will not be tracked."
-              data-toggle='tooltip'
-              href="${course_target}">
-            <strong>${_("View Course")}</strong>
+          <div class="banner-links">
+            <a href="${course_target}">
+              <strong>${_("View Course")}</strong>
             </a>
+            <span class="tooltip">View the course as an anonymous user. Some content will be unavailable and progress will not be tracked.</span>
+          </div>
+
           % endif
 
           <%
@@ -194,14 +198,15 @@ from six import string_types, text_type
             else:
               href_class = "register"
           %>
-          <a
-            href="${reg_href}"
-            class="${href_class}"
-            data-toggle="tooltip"
-            title="Enroll in the course to take advantage of advanced assessments and keep track of course progress."
-          >
-            ${_("Enroll to Get Started")}
-          </a>
+          <div class="banner-links">
+            <a
+              href="${reg_href}"
+              class="${href_class}"
+            >
+              ${_("Enroll to Get Started")}
+            </a>
+            <span class="tooltip">View the course as an anonymous user. Some content will be unavailable and progress will not be tracked.</span>
+          </div>
           <div id="register_error"></div>
         %endif
         </div>

--- a/mitx/lms/templates/main.html
+++ b/mitx/lms/templates/main.html
@@ -79,7 +79,6 @@ from pipeline_mako import render_require_js_path_overrides
   % endif
   <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
   <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
-  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 
   <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}" />
 
@@ -222,11 +221,6 @@ from pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/accordion.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/smooth-scroll.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/common-scripts.js')}" charset="utf-8"></script>
-  <script>
-    (function(){
-      $('[data-toggle=tooltip]').tooltip();
-    })();
-  </script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
 </body>
 </html>


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-481

### Description
Apply the customizations requested in the document (document's link in the ticket).
This PR reverts the changes in #65 as that didn't as expected.

Add texts on hover on buttons on course about page for public courses only.
![image](https://user-images.githubusercontent.com/42166091/82665234-d13b6680-9c4c-11ea-84cb-69f2fb1d3f27.png)


![image](https://user-images.githubusercontent.com/42166091/82665238-d4ceed80-9c4c-11ea-8741-ea3b976b5878.png)


and for enrolled users
![image](https://user-images.githubusercontent.com/42166091/82665775-efee2d00-9c4d-11ea-8f33-99eebdbdfead.png)
