### PR TITLE
Fix the staff info modal design issue

### DIFF
--- a/mitx/lms/static/sass/base/_reset.scss
+++ b/mitx/lms/static/sass/base/_reset.scss
@@ -41,12 +41,14 @@ body.view-in-course .content-wrapper,
 }
 
 #main {
-    position: relative;
-    z-index: 3;
 
     .view-profile & {
         max-width: inherit;
         padding: 0;
+    }
+
+    .staff-modal {
+        margin-left: -40% !important;
     }
 }
 


### PR DESCRIPTION
### Description
Fixes the bug that causes the staff modal to hide behind the overlay shadow.


**Before**
![image](https://user-images.githubusercontent.com/42166091/84469292-24c43180-ac9a-11ea-9285-c91ceed162bf.png)

**After**
![image](https://user-images.githubusercontent.com/42166091/84469302-2beb3f80-ac9a-11ea-879c-db2912f02143.png)
