### PR TITLE
Meta tags moved to all pages for SEO

### DIFF
--- a/mitx/lms/templates/courseware/course_about.html
+++ b/mitx/lms/templates/courseware/course_about.html
@@ -21,11 +21,6 @@ from six import string_types, text_type
 <%block name="headextra">
   ## OG (Open Graph) title and description added below to give social media info to display
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta data-rh="true" property="og:title" content="${course.display_name_with_default}" />
-  <meta data-rh="true" property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
-  <meta data-rh="true" property="title" content="${course.display_name_with_default}" />
-  <meta data-rh="true" property="description" content="${get_course_about_section(request, course, 'short_description')}" />
-  <meta data-rh="true" property="image" content="${request.build_absolute_uri(course_image_urls['large'])}" />
 </%block>
 
 <%block name="js_extra">

--- a/mitx/lms/templates/main.html
+++ b/mitx/lms/templates/main.html
@@ -23,6 +23,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 from openedx.core.release import RELEASE_LINE
 from pipeline_mako import render_require_js_path_overrides
 
+from courseware.courses import get_course_about_section
+from openedx.core.lib.courses import course_image_url
+
 %>
 <!DOCTYPE html>
 <!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
@@ -31,6 +34,15 @@ from pipeline_mako import render_require_js_path_overrides
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    % if course:
+        <meta data-rh="true" property="og:title" content="${course.display_name_with_default}" />
+        <meta data-rh="true" property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
+        <meta data-rh="true" property="title" content="${course.display_name_with_default}" />
+        <meta data-rh="true" property="description" content="${get_course_about_section(request, course, 'short_description')}" />
+        <meta data-rh="true" property="image" content="${request.build_absolute_uri(course_image_url(course))}" />
+    % endif
+
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
ticket link 
https://edlyio.atlassian.net/browse/EDE-830

description: for some public courses the syllabus and inner pages were accessible without login so SERP was not able to pick description as it was only on about page, moved the tags on all the pages so that public courses can have better SEO