### PR TITLE
EDE-1097 Labels on the login fields are getting hide on Firefox

### DIFF
--- a/mitx/lms/static/sass/views/_login-register.scss
+++ b/mitx/lms/static/sass/views/_login-register.scss
@@ -170,6 +170,7 @@
                                 position: absolute;
                                 left: $baseline*0.75;
                                 right: auto;
+                                z-index: 1;
                                 top: -($baseline*0.75);
                             }
 


### PR DESCRIPTION
### [EDE-1097](https://edlyio.atlassian.net/browse/EDE-1097) Labels on the login fields are getting hide on Firefox